### PR TITLE
refactor(etl): introduce `data` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ word2vec.db
 nearest.pickle
 static/assets/js/british_spellings.js
 bin/
+data/
 lib/
 pyvenv.cfg

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ This is a spanish version of [Semantle](https://semantle.novalis.org).
 
 ## Running locally
 ### One-time setup
-1. Get spanish Word2vec dataset from [Spanish Billion Word Corpus and Embeddings](https://crscardellino.github.io/SBWCE/). Download the word2vec binary format.
-1. Save dataset on the parent directory
-1. Create a python virtual environment: `python3 -m venv`
+1. Get spanish Word2vec dataset from [Spanish Billion Word Corpus and Embeddings](https://crscardellino.github.io/SBWCE/). Download the word2vec binary format to the `data` directory. _Unzip it_
+1. Create a python virtual environment: `python3 -m venv .`
 1. Activate the environment: `source bin/activate`
 1. Install all dependencies: `python3 -m pip install -r requirements.txt`
 1. Load model into sqlite db: `python3 dump-vecs.py`. Takes ~5min in a 2.4 GHz Intel Core i5 MacBook Pro

--- a/dump-hints.py
+++ b/dump-hints.py
@@ -12,7 +12,7 @@ import code, traceback, signal
 word_limit = None
 t_word2vec = time.process_time()
 print("loading word2vec file...")
-model = word2vec.KeyedVectors.load_word2vec_format("../SBW-vectors-300-min5.bin", binary=True, limit=word_limit)
+model = word2vec.KeyedVectors.load_word2vec_format("data/SBW-vectors-300-min5.bin", binary=True, limit=word_limit)
 print(f'done in {time.process_time() - t_word2vec} seconds')
 
 simple_word = re.compile("^[a-z]*")

--- a/dump-vecs.py
+++ b/dump-vecs.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 
 t_word2vec = time.process_time()
 print("loading word2vec file...")
-model = word2vec.KeyedVectors.load_word2vec_format("../SBW-vectors-300-min5.bin", binary=True)
+model = word2vec.KeyedVectors.load_word2vec_format("data/SBW-vectors-300-min5.bin", binary=True)
 print(f'done in {time.process_time() - t_word2vec} seconds')
 
 print("creating word2vec table...")


### PR DESCRIPTION
Let's use the `data` directory for all ETL files that we use locally to
generate the data base, and that should not be commited or deployed.