### PR TITLE
feat(etl): drop hint tables and run sanity check after load

### DIFF
--- a/store-hints.py
+++ b/store-hints.py
@@ -6,9 +6,13 @@ from tqdm import tqdm
 
 con = sqlite3.connect('word2vec.db')
 cur = con.cursor()
-cur.execute("""create table if not exists nearby (word text, neighbor text, similarity float, percentile integer)""")
-
+cur.execute("""drop table if exists similarity_range;""")
+cur.execute("""drop table if exists nearby;""")
 con.commit()
+
+cur.execute("""create table if not exists nearby (word text, neighbor text, similarity float, percentile integer)""")
+con.commit()
+
 cur.execute("""create unique index if not exists nearby_words on nearby (word, neighbor)""")
 con.commit()
 
@@ -27,11 +31,20 @@ for i, (secret, neighbors) in enumerate(nearest.items()):
         con.commit()
     for idx, (score, neighbor) in enumerate(neighbors):
         con.execute ("insert into nearby (word, neighbor, similarity, percentile) values (?, ?, ?, ?)", (secret, neighbor, "%s" % score, (1 + idx)))
-
-    top = neighbors[-2][0]
-    top10 = neighbors[-12][0]
-    rest = neighbors[0][0]
-    con.execute ("insert into similarity_range (word, top, top10, rest) values (?, ?, ?, ?)", (secret, "%s" % top, "%s" % top10, "%s" % rest))
+    try:
+        top = neighbors[-2][0]
+        top10 = neighbors[-12][0]
+        rest = neighbors[0][0]
+        con.execute ("insert into similarity_range (word, top, top10, rest) values (?, ?, ?, ?)", (secret, "%s" % top, "%s" % top10, "%s" % rest))
+    except IndexError:
+        print(f'{secret} does not have enough neighbors: {len(neighbors)}')
     t.update()
 
 con.commit()
+
+# Validate hints are sane
+max_percentile_query = cur.execute("select max(percentile) from (select word, max(percentile) as percentile from nearby group by word)")
+max_percentile = list(max_percentile_query.fetchone())[0]
+if max_percentile != 1000:
+    raise RuntimeError(f'maximum percentile is {max_percentile}, should be 1000')
+con.close()


### PR DESCRIPTION
This commit drops the `nearby` and `similarity_range` tables prior to
loading. This makes it easier to run the command w/o having to manually
drop the tables.

It also does a sanity check after loading, to ensure the data makes
sense. Currently the only check is to check theres 1k `nearby` records
per secret word. I've messed that up more than once.